### PR TITLE
Feature/generatecerts

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -417,7 +417,30 @@
 								</mapping>
 							</mappings>
 							<preinstallScriptlet>
-								<script>echo "installing now"</script>
+								<script>
+echo "installing now"
+# Generate a certificate if it isn't already in /etc/keystorejetty
+if [ ! -f /etc/keystorejetty ] ; then
+  # Get the IP of the host; first try external with a timeout of 15s
+  ip=$(/usr/bin/curl -m15 -s http://ifconfig.me/ip)
+  if ! echo $ip |grep -E [0-9]+\.[0-9]+\.[0-9]+\.[0-9]+ >/dev/null ; then
+    ip=$(hostname -i)
+  fi
+  if echo $ip |grep  ^127 >/dev/null; then
+     defaultdev=$(/sbin/route  | awk  '/^default/ { print $8}')
+     ip=$(ip addr show dev $defaultdev |awk '/inet / { X = split($2, A, "/") ; print A[1]}')
+  fi
+
+  echo "Generating key and certificate with CN=$ip"
+  keytool -genkey -keyalg RSA -alias jetty -keystore /etc/keystorejetty -validity 730 -keypass password -storepass password -dname "CN=$ip, O=fiware" -keysize 2048
+  chmod 640 /etc/keystorejetty
+  echo "Done"
+fi
+# To see the certificate:
+# keytool -list -storepass password -keystore /etc/keystorejetty  -rfc |openssl x509 -text
+
+#OBF of password is OBF:1v2j1uum1xtv1zej1zer1xtn1uvk1v1v
+								</script>
 							</preinstallScriptlet>
 							<postinstallScriptlet>
 								<script>echo "installed in /opt/fiware-sdc"</script>

--- a/src/assembly/jetty/bin/generateselfsigned.sh
+++ b/src/assembly/jetty/bin/generateselfsigned.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+if [ $# -eq 1 ] ; then
+  ip=$1
+else
+  ip=$(/usr/bin/curl -m15 -s http://ifconfig.me/ip)
+  if ! echo $ip |grep -E [0-9]+\.[0-9]+\.[0-9]+\.[0-9]+ >/dev/null ; then
+     ip=$(hostname -i)
+  fi
+  if echo $ip |grep  ^127 >/dev/null ; then
+     defaultdev=$(/sbin/route  | awk  '/^default/ { print $8}')
+     ip=$(ip addr show dev $defaultdev |awk '/inet / { X = split($2, A, "/") ; print A[1]}')
+  fi
+fi
+echo "Generating certificate with CN=$ip"
+keytool -genkey -keyalg RSA -alias jetty -keystore /etc/keystorejetty.new -validity 730 -keypass password -storepass password -dname "CN=$ip, O=fiware" -keysize 2048
+
+if [ -f /etc/keystorejetty.new ] ; then
+   mv /etc/keystorejetty.new /etc/keystorejetty
+   echo "key and certificate generated in /etc/keystorejetty"
+fi
+
+

--- a/src/assembly/jetty/bin/importcert.sh
+++ b/src/assembly/jetty/bin/importcert.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+# $1: key
+# $2: cert
+# $3: chain
+if [ $# -ne 3 ] ; then
+  echo "Use $0 <keyfile> <certfile> <chainfile>"
+  exit
+fi
+cat $2 $3 > fullchain.crt
+openssl pkcs12 -inkey $1 -in fullchain.crt -export -out jetty.pkcs12 -password pass:password
+keytool -importkeystore -srckeystore jetty.pkcs12 -srcstoretype PKCS12 -destkeystore /etc/keystorejetty.new -srcstorepass password -deststorepass password -destalias jetty -alias 1
+chmod 640 /etc/keystorejetty
+rm fullchain.crt jetty.pkcs12
+if [ -f /etc/keystorejetty.new ] ; then
+   mv /etc/keystorejetty.new /etc/keystorejetty
+   echo "content imported into /etc/keystorejetty"
+fi
+

--- a/src/assembly/jetty/etc/jetty-ssl.xml
+++ b/src/assembly/jetty/etc/jetty-ssl.xml
@@ -7,10 +7,10 @@
 <!-- and either jetty-https.xml or jetty-spdy.xml (but not both)   -->
 <!-- ============================================================= -->
 <Configure id="sslContextFactory" class="org.eclipse.jetty.util.ssl.SslContextFactory">
-  <Set name="KeyStorePath"><Property name="jetty.base" default="." />/<Property name="jetty.keystore" default="etc/keystore"/></Set>
+  <Set name="KeyStorePath"><Property name="jetty.keystore" default="etc/keystore"/></Set>
   <Set name="KeyStorePassword"><Property name="jetty.keystore.password" default="OBF:1vny1zlo1x8e1vnw1vn61x8g1zlu1vn4"/></Set>
   <Set name="KeyManagerPassword"><Property name="jetty.keymanager.password" default="OBF:1u2u1wml1z7s1z7a1wnl1u2g"/></Set>
-  <Set name="TrustStorePath"><Property name="jetty.base" default="." />/<Property name="jetty.truststore" default="etc/keystore"/></Set>
+  <Set name="TrustStorePath"><Property name="jetty.truststore" default="etc/keystore"/></Set>
   <Set name="TrustStorePassword"><Property name="jetty.truststore.password" default="OBF:1vny1zlo1x8e1vnw1vn61x8g1zlu1vn4"/></Set>
   <Set name="EndpointIdentificationAlgorithm"></Set>
   <Set name="NeedClientAuth"><Property name="jetty.ssl.needClientAuth" default="false"/></Set>

--- a/src/assembly/jetty/start.d/ssl.ini
+++ b/src/assembly/jetty/start.d/ssl.ini
@@ -7,15 +7,15 @@
 jetty.secure.port=8443
 
 # Setup a demonstration keystore and truststore
-jetty.keystore=etc/keystore
-jetty.truststore=etc/keystore
+jetty.keystore=/etc/keystorejetty
+jetty.truststore=/etc/keystorejetty
 
 # Set the demonstration passwords.
 # Note that OBF passwords are not secure, just protected from casual observation
 # See http://www.eclipse.org/jetty/documentation/current/configuring-security-secure-passwords.html
-jetty.keystore.password=OBF:1yfa1s3g1toq1vun1t331vun1to41s3m1yew
-jetty.keymanager.password=OBF:1yfa1s3g1toq1vun1t331vun1to41s3m1yew
-jetty.truststore.password=OBF:1yfa1s3g1toq1vun1t331vun1to41s3m1yew
+jetty.keystore.password=OBF:1v2j1uum1xtv1zej1zer1xtn1uvk1v1v
+jetty.keymanager.password=OBF:1v2j1uum1xtv1zej1zer1xtn1uvk1v1v
+jetty.truststore.password=OBF:1v2j1uum1xtv1zej1zer1xtn1uvk1v1v
 
 # Set the client auth behavior
 # Set to true if client certificate authentication is required


### PR DESCRIPTION


#### Reviewers
@jesuspg @hmunfru

#### Description
This are the same changes than https://github.com/telefonicaid/fiware-paas/pull/152



Create a keystore as /etc/keystorejetty, but only if this file does not exists.

The certificate is auto-signed.

The CN of the certificate is obtained according this algorithm:
-Check external IP using : /usr/bin/curl -m15 -s http://ifconfig.me/ip (there is a timeout of 15s)
-If this commands doesn't get a valid IP, try to obtain a IP with hostname -i
-If this command returns 127.0.0.1, get the IP of the interface where is the default route

Also a pair of new scripts are provided:
-A script to generate the keystore: if no parameter is provided, use the algorithm described, otherwise use the parameter received as CN.
-A script to create a keystore from a keyfile, cert, and certchain. This is useful to import a wildcart cert from an Apache host.

The other changes are in the configuration:
-Use /etc/keystorejetty instead of a file inside /opt/fiware-paas
-Use "password" as password.

#### Testing
No tested, but these are exactly the same changes than in fiware-paas.