### PR TITLE
update document with information about HTTPS certificates

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -16,7 +16,7 @@ Documentation
 =============
 
 -   `User and Programmers Guide <doc/user_guide.rst>`_
--   `Installation and Administration Guide <doc/admin_guide.rst>`_
+-   `Installation and Administration Guide <doc/installation-guide.rst>`_
 
 .. IMAGES
 

--- a/doc/installation-guide.rst
+++ b/doc/installation-guide.rst
@@ -36,9 +36,9 @@ It is a a maven application:
 
        $ mvn assembly:assembly -DskipTests
        
-	   $ cp target/distribution/puppwrapper-dist {folder}
-       $ ./generateselfsigned.sh start on {folder}/puppetwrapper-dist/bin
-       $ ./jetty.sh start on {folder}/puppetwrapper-dist/bin
+       $ cp target/distribution/sdc-server-dist {folder}
+       $ {folder}/sdc-server-dist/bin/generateselfsigned.sh start 
+       $ cd {folder}/sdc-server-dist/bin ; ./jetty.sh start 
 
 -  You can generate a rpm o debian packages (using profiles in pom)
 
@@ -56,6 +56,7 @@ It is a a maven application:
    		$ mvn package -P rpm -DskipTests
    		(created target/rpm/sdc/RPMS/noarch/fiware-sdc-XXXX.noarch.rpm)
 
+Please, be aware  that the supported installation method is the RPM package. If you use other method, some extra steps may be required. For example you would need to generate manually the certificate (See the section about "Configuring the HTTPS certificate" for more information):
 
 Installation instructions
 -------------------------

--- a/doc/installation-guide.rst
+++ b/doc/installation-guide.rst
@@ -474,7 +474,7 @@ Configuring the HTTPS certificate
 The service is configured to use HTTPS to secure the communication between clients and the server. One central point in HTTPS security is the certificate which guarantee the server identity.
 
 Quickest solution: using a self-signed certificate
-,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The service works "out of the box" against passive attacks (e.g. a sniffer) because a self-signed certificated is generated automatically when the RPM is installed. Any certificate includes a special field call "CN" (Common name) with the identity of the host: the generated certificate uses as identity the IP of the host.
 
@@ -489,7 +489,7 @@ If you need to regenerate a self-signed certificate with a different IP address 
 By the way, the self-signed certificate is at /etc/keystorejetty. This file wont be overwritten although you reinstall the package. The same way, it wont be removed automatically if you uninstall de package.
 
 Advanced solution: using certificates signed by a CA
-,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Although a self-signed certificate works against passive attack, it is not enough by itself to prevent active attacks, specifically a "man in the middle attack" where an attacker try to impersonate the server. Indeed, any browser warns user against self-signed certificates. To avoid these problems, a certificate conveniently signed by a CA may be used.
 
@@ -506,7 +506,7 @@ It's possible that you already have a wild certificate securing your portal, but
 .. code::
 
     # usually, on an Apache installation, the certificate files are at /etc/ssl/private
--    /opt/fiware-sdc/bin/importcert.sh key.pem cert.crt chain.crt
+    /opt/fiware-sdc/bin/importcert.sh key.pem cert.crt chain.crt
 
 If you have a different configuration, for example your organization has got its own PKI, please refer to: http://docs.codehaus.org/display/JETTY/How%2bto%2bconfigure%2bSSL
 

--- a/doc/installation-guide.rst
+++ b/doc/installation-guide.rst
@@ -37,6 +37,7 @@ It is a a maven application:
        $ mvn assembly:assembly -DskipTests
        
 	   $ cp target/distribution/puppwrapper-dist {folder}
+       $ ./generateselfsigned.sh start on {folder}/puppetwrapper-dist/bin
        $ ./jetty.sh start on {folder}/puppetwrapper-dist/bin
 
 -  You can generate a rpm o debian packages (using profiles in pom)
@@ -465,3 +466,46 @@ Finally, to start chef-client in boot time
    :target: https://coveralls.io/r/telefonicaid/fiware-sdc
 .. |help stackoverflow| image:: http://b.repl.ca/v1/help-stackoverflow-orange.png
    :target: http://www.stackoverflow.com
+
+Configuring the HTTPS certificate
+---------------------------------
+
+The service is configured to use HTTPS to secure the communication between clients and the server. One central point in HTTPS security is the certificate which guarantee the server identity.
+
+Quickest solution: using a self-signed certificate
+,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+
+The service works "out of the box" against passive attacks (e.g. a sniffer) because a self-signed certificated is generated automatically when the RPM is installed. Any certificate includes a special field call "CN" (Common name) with the identity of the host: the generated certificate uses as identity the IP of the host.
+
+The IP used in the certificate should be the public IP (i.e. the floating IP). The script which generates the certificate knows the public IP asking to an Internet service (http://ifconfig.me/ip). Usually this obtains the floating IP of the server, but of course it wont work without a direct connection to Internet.
+
+If you need to regenerate a self-signed certificate with a different IP address (or better, a convenient configured hostname), please run:
+
+.. code::
+
+    /opt/fiware-sdc/bin/generateselfsigned.sh myhost.mydomain.org
+
+By the way, the self-signed certificate is at /etc/keystorejetty. This file wont be overwritten although you reinstall the package. The same way, it wont be removed automatically if you uninstall de package.
+
+Advanced solution: using certificates signed by a CA
+,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+
+Although a self-signed certificate works against passive attack, it is not enough by itself to prevent active attacks, specifically a "man in the middle attack" where an attacker try to impersonate the server. Indeed, any browser warns user against self-signed certificates. To avoid these problems, a certificate conveniently signed by a CA may be used.
+
+If you need a certificate signed by a CA, the more cost effective and less intrusive practice when an organization has several services is to use a wildcard certificate, that is, a common certificate among all the servers of a DNS domain. Instead of using an IP or hostname in the CN, an expression as "*.fiware.org" is used.
+
+This solution implies:
+
+* The service must have a DNS name in the domain specified in the wildcard certificate. For example, if the domain is "*.fiware.org" a valid name may be "sdc.fiware.org".
+* The clients should use this hostname instead of the IP
+* The file /etc/keystorejetty must be replaced with another one generated from the wildcard certificate, the corresponding private key and other certificates signing the wild certificate.
+
+It's possible that you already have a wild certificate securing your portal, but Apache server uses a different file format. A tool is provided to import a wildcard certificate, a private key and a chain of certificates, into /etc/keystorejetty:
+
+.. code::
+
+    # usually, on an Apache installation, the certificate files are at /etc/ssl/private
+-    /opt/fiware-sdc/bin/importcert.sh key.pem cert.crt chain.crt
+
+If you have a different configuration, for example your organization has got its own PKI, please refer to: http://docs.codehaus.org/display/JETTY/How%2bto%2bconfigure%2bSSL
+


### PR DESCRIPTION

Reviewers

@jesuspg @hmunfru

#### Description
Documentation concerning SSL certificates.

This is the same than the PaaS part, but with some changes in paths and format.

Also fix README.rst link
#### Testing
Tested that the document showed in the browser is OK
